### PR TITLE
Add TCP/UDP Load Balancing Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ NGINX Plus Router is built on top of OpenShift Template Router. Below are the ke
 * **Familiar operational experience.** NGINX Plus Router is integrated in OpenShift through the Template Router software, the same software that underpins the default Router implementation. As a result, you get the familiar operational experience, which makes it easier to migrate from the default Router implementation. 
 * **NGINX Plus performance and stability.** With NGINX Plus Router you get the performance and reliability of NGINX Plus software.
 * **Latest NGINX Plus features.** We are also excited to bring our new features, such as native support for gRPC load balancing, into the OpenShift Router. As new features are made available in NGINX Plus, they can be incorporated into the Router’s capabilities. 
+* **Support for TCP/UDP load balancing.** NGINX Plus Router brings support for load balancing TCP/UDP applications, including supporting edge TLS termination and re-encryption for TCP, via a TCP/UDP load balancing [extension](docs/configuration.md/#tcpudp-load-balancing-extension).
 
 ## How To Get Started
 
 * Read the [installation guide](docs/nginx-plus-router-install.md) for installation instructions.
 * See how to use NGINX Plus Router for edge load balancing of an example HTTP application in our [Cafe Application example](examples/cafe-app).
+* See how to use NGINX Plus Router for edge load balancing of a TCP/UDP application in our TCP/UDP [example](examples/tcp-udp).
 
 ## Contacts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,7 @@
 1. [Building the Router image](build-image.md)
 1. [Configuration](configuration.md)
 
+## Examples
+
+* [Cafe App](../examples/cafe-app/README.md)
+* [TCP/UDP Load Balancing](../examples/tcp-udp/README.md)

--- a/examples/tcp-udp/README.md
+++ b/examples/tcp-udp/README.md
@@ -1,0 +1,98 @@
+# TCP/UDP Load Balancing Example
+
+In this example we deploy the NGINX Plus OpenShift Router, a DNS server and then configure both TCP and UDP load balancing for the DNS server using routes.
+
+## Prerequisites
+
+* We use `dig` for testing. Make sure it is installed on your machine.
+* Make sure to open port 5353 in the firewall for both TCP and UDP traffic on the node where the Router is running:
+    ```
+    $ sudo iptables -I OS_FIREWALL_ALLOW -p tcp --dport 5353 -j ACCEPT
+    $ sudo iptables -I OS_FIREWALL_ALLOW -p udp --dport 5353 -j ACCEPT
+    ```
+
+## 1. Deploy the NGINX Plus Router
+
+1. Follow the installation instructions for [NGINX Plus](../../docs/nginx-plus-router-install.md).
+
+1. Save the public IP address of the node where the Router is running into a shell variable:
+    ```
+    $ export ROUTER_IP=xxx.xxx.xxx.xxx
+    ```
+1. Save port 5353 of the Router into a shell variable:
+    ```
+    $ export ROUTER_5353_PORT=5353
+    ```
+
+### 2. Deploy the DNS Server
+
+We deploy two replicas of [CoreDNS](https://coredns.io/), configured to forward DNS queries to `8.8.8.8`.
+
+Deploy the DNS server:
+
+```
+$ kubectl apply -f dns.yaml
+```
+
+## 3. Create the Routes
+
+```
+$ oc create -f dns-udp-route.yaml
+$ oc create -f dns-tcp-route.yaml
+```
+
+### 3. Test the DNS Server
+
+To test that the configured TCP/UDP load balancing works, we resolve the name `openshift.io` using our DNS server available through the Router:
+
+1. Resolve `openshift.io` through UDP:
+    ```
+    $ dig @$ROUTER_IP -p $ROUTER_5353_PORT openshift.io
+
+    ; <<>> DiG 9.10.6 <<>> @192.168.99.100 -p 5353 openshift.io
+    ; (1 server found)
+    ;; global options: +cmd
+    ;; Got answer:
+    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 34229
+    ;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
+
+    ;; OPT PSEUDOSECTION:
+    ; EDNS: version: 0, flags:; udp: 512
+    ;; QUESTION SECTION:
+    ;openshift.io.			IN	A
+
+    ;; ANSWER SECTION:
+    openshift.io.		6	IN	A	52.44.3.11
+    openshift.io.		6	IN	A	52.71.98.175
+
+    ;; Query time: 47 msec
+    ;; SERVER: 192.168.99.100#5353(192.168.99.100)
+    ;; WHEN: Fri Aug 17 12:21:42 PDT 2018
+    ;; MSG SIZE  rcvd: 97
+    ```
+    
+1. Resolve `openshift.io` through TCP:
+    ```
+    $ dig @$ROUTER_IP -p $ROUTER_5353_PORT openshift.io +tcp
+
+    ; <<>> DiG 9.10.6 <<>> @192.168.99.100 -p 5353 openshift.io +tcp
+    ; (1 server found)
+    ;; global options: +cmd
+    ;; Got answer:
+    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24550
+    ;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
+
+    ;; OPT PSEUDOSECTION:
+    ; EDNS: version: 0, flags:; udp: 512
+    ;; QUESTION SECTION:
+    ;openshift.io.			IN	A
+
+    ;; ANSWER SECTION:
+    openshift.io.		7	IN	A	52.44.3.11
+    openshift.io.		7	IN	A	52.71.98.175
+
+    ;; Query time: 62 msec
+    ;; SERVER: 192.168.99.100#5353(192.168.99.100)
+    ;; WHEN: Fri Aug 17 12:22:12 PDT 2018
+    ;; MSG SIZE  rcvd: 97
+    ```

--- a/examples/tcp-udp/dns-tcp-route.yaml
+++ b/examples/tcp-udp/dns-tcp-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Route
+metadata: 
+  name: tcp-route
+  annotations:
+    nginx.router.openshift.io/protocol: tcp
+    nginx.router.openshift.io/port: "5353"
+spec:
+  host: 5353.tcp.nginx.router.openshift.io
+  to:
+    kind: Service
+    name: coredns
+  port:
+    targetPort: 5353

--- a/examples/tcp-udp/dns-udp-route.yaml
+++ b/examples/tcp-udp/dns-udp-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Route
+metadata: 
+  name: udp-route
+  annotations:
+    nginx.router.openshift.io/protocol: udp
+    nginx.router.openshift.io/port: "5353"
+spec:
+  host: 5353.udp.nginx.router.openshift.io
+  to:
+    kind: Service
+    name: coredns
+  port:
+    targetPort: 5353

--- a/examples/tcp-udp/dns.yaml
+++ b/examples/tcp-udp/dns.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+data:
+  Corefile: |
+    .:5353 {
+      forward . 8.8.8.8:53
+      log
+    }
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: coredns
+  template:
+    metadata:
+      labels:
+        app: coredns
+    spec:
+      containers:
+      - name: coredns
+        image: coredns/coredns:1.2.0
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+          readOnly: true
+        ports:
+        - containerPort: 5353
+          name: dns
+          protocol: UDP
+        - containerPort: 5353
+          name: dns-tcp
+          protocol: TCP
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns
+spec:
+  selector:
+   app: coredns 
+  ports:
+  - name: dns
+    port: 5353
+    protocol: UDP
+  - name: dns-tcp
+    port: 5353
+    protocol: TCP

--- a/src/conf/nginx-config.template
+++ b/src/conf/nginx-config.template
@@ -10,10 +10,10 @@
 {{ $logLevel := firstMatch "info|notice|warn|error|crit|alert|emerg" (env "ROUTER_LOG_LEVEL") "warn" }}
 worker_processes  auto;
 {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
-error_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}} {{ $logLevel }}; 
+error_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}} {{ $logLevel }};
 {{ else }}
 error_log  /var/lib/nginx/log/error.log {{ $logLevel }};
-{{ end }} 
+{{ end }}
 pid        /var/lib/nginx/run/nginx.pid;
 worker_rlimit_nofile 8192;
 worker_shutdown_timeout {{ env "ROUTER_DEFAULT_TUNNEL_TIMEOUT" "1h" }};
@@ -68,20 +68,16 @@ http {
 {{- if eq (env "ROUTER_CIPHERS" "intermediate") "modern" }}
   # Modern cipher suite (no legacy browser support) from https://wiki.mozilla.org/Security/Server_Side_TLS
   ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256;
-{{ else }}
-  {{- if eq (env "ROUTER_CIPHERS" "intermediate") "intermediate" }}
+{{- else if eq (env "ROUTER_CIPHERS" "intermediate") "intermediate" }}
   # Intermediate cipher suite (default) from https://wiki.mozilla.org/Security/Server_Side_TLS
   ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
-  {{ else }}
-    {{- if eq (env "ROUTER_CIPHERS" "intermediate") "old" }}
+{{- else if eq (env "ROUTER_CIPHERS" "intermediate") "old" }}
   # Old cipher suite (maximum compatibility but insecure) from https://wiki.mozilla.org/Security/Server_Side_TLS
   ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:DES-CBC3-SHA:HIGH:SEED:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!RSAPSK:!aDH:!aECDH:!EDH-DSS-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!SRP;
-    {{- else }}
+{{- else }}
   # user provided list of ciphers (Colon separated list as seen above)
   # the env default is not used here since we can't get here with empty ROUTER_CIPHERS
   ssl_ciphers {{env "ROUTER_CIPHERS" "ECDHE-ECDSA-CHACHA20-POLY1305"}};
-    {{- end }}
-  {{- end }}
 {{- end }}
 
   map $http_upgrade $connection_upgrade {
@@ -139,23 +135,24 @@ http {
 {{ end }}
 
     server_name _;
-    
+
     ssl_certificate {{ printf "%s/tls.crt" (env "DEFAULT_CERTIFICATE_DIR" "/etc/pki/tls/private") }};
     ssl_certificate_key {{ printf "%s/tls.key" (env "DEFAULT_CERTIFICATE_DIR" "/etc/pki/tls/private") }};
 
-    error_page 503 /error-page-503.html; 
+    error_page 503 /error-page-503.html;
 
     location / {
       return 503;
     }
-    
+
     location = /error-page-503.html {
       root /var/lib/nginx/conf;
     }
   }
 
 {{- range $cfgHost, $configs := $httpAliases }}
-  {{ range $cfg := $configs }}
+  {{- range $cfg := $configs }}
+    {{- if not (and (firstMatch "tcp|udp" (index $cfg.Annotations "nginx.router.openshift.io/protocol")) (isInteger (index $cfg.Annotations "nginx.router.openshift.io/port"))) }}
   upstream be_{{$cfg.Namespace}}_{{$cfg.Name}} {
       {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
         {{ if ne $balanceAlgo "round_robin" }}
@@ -165,7 +162,7 @@ http {
     zone {{$cfg.Namespace}}_{{$cfg.Name}} 64k;
       {{ if gt $cfg.ActiveEndpoints 0 }}
         {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
-        # endpoints of {{$serviceUnitName}} 
+        # endpoints of {{$serviceUnitName}}
           {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
             {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
     server {{$endpoint.IP}}:{{$endpoint.Port}} weight={{$weight}};
@@ -181,17 +178,19 @@ http {
         {{ end }}
       {{ end }}
     }
+    {{ end }}
   {{ end }}
 
   {{ $primaryCfgIdx := getPrimaryAliasKey $configs }}
   {{ $primaryCfg := index $configs $primaryCfgIdx }}
+  {{- if not (and (firstMatch "tcp|udp" (index $primaryCfg.Annotations "nginx.router.openshift.io/protocol")) (isInteger (index $primaryCfg.Annotations "nginx.router.openshift.io/port"))) }}
 
-  # the primary route is {{ $primaryCfgIdx }} 
+  # the primary route is {{ $primaryCfgIdx }}
   server {
     {{ if or (eq $primaryCfg.TLSTermination "") (or (eq $primaryCfg.InsecureEdgeTerminationPolicy "Allow") (eq $primaryCfg.InsecureEdgeTerminationPolicy "Redirect")) }}
     listen {{env "ROUTER_SERVICE_HTTP_PORT" "80"}}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} proxy_protocol{{ end }};
     {{ end }}
-  
+
     server_name {{genCertificateHostName $cfgHost $primaryCfg.IsWildcard }};
 
     status_zone {{$cfgHost}};
@@ -249,7 +248,7 @@ http {
             {{ else }}
       grpc_ssl_verify off;
             {{ end }}
-        {{ end }}
+          {{ end }}
       grpc_pass      grpcs://be_{{$cfg.Namespace}}_{{$cfg.Name}};
         {{ else }}
       grpc_pass      grpc://be_{{$cfg.Namespace}}_{{$cfg.Name}};
@@ -263,7 +262,7 @@ http {
           {{ with $keepalive := (index $cfg.Annotations "nginx.router.openshift.io/keepalive") }}
             {{ if and (isInteger $keepalive) (ne $keepalive "0") }}
       proxy_set_header Connection "";
-           {{ end }}
+            {{ end }}
           {{ end }}
         {{ end }}
 
@@ -286,7 +285,7 @@ http {
             {{ else }}
       proxy_ssl_verify off;
             {{ end }}
-        {{ end }}
+          {{ end }}
       proxy_pass      https://be_{{$cfg.Namespace}}_{{$cfg.Name}};
         {{ else }}
       proxy_pass      http://be_{{$cfg.Namespace}}_{{$cfg.Name}};
@@ -296,6 +295,7 @@ http {
     }
     {{ end }}
   }
+  {{ end -}}
 {{ end -}}
 }
 
@@ -314,10 +314,39 @@ stream {
                      '$protocol $status $bytes_sent $bytes_received '
                      '$session_time "$ssl_preread_server_name" $dest_internal_passthrough"';
   {{ end }}
+  {{ with $format := env "ROUTER_SYSLOG_FORMAT_FOR_TCP_UDP" }}
+  log_format stream '{{ $format }}';
+  {{ else }}
+  log_format stream '$remote_addr [$time_local] '
+                     '$protocol $status $bytes_sent $bytes_received '
+                     '$session_time "$upstream_addr"';
+  {{ end }}
 
   proxy_timeout {{ env "ROUTER_DEFAULT_CLIENT_TIMEOUT" "30s" }};
   proxy_connect_timeout {{ env "ROUTER_DEFAULT_CONNECT_TIMEOUT" "5s" }};
   map_hash_bucket_size 256;
+
+  # Prevent vulnerability to POODLE attacks (CVE‑2014‑3566) - omit SSLv3
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+  # The default cipher suite can be selected from the three sets recommended by https://wiki.mozilla.org/Security/Server_Side_TLS,
+  # or the user can provide one using the ROUTER_CIPHERS environment variable.
+  # By default when a cipher set is not provided, intermediate is used.
+{{- if eq (env "ROUTER_CIPHERS" "intermediate") "modern" }}
+  # Modern cipher suite (no legacy browser support) from https://wiki.mozilla.org/Security/Server_Side_TLS
+  ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256;
+{{- else if eq (env "ROUTER_CIPHERS" "intermediate") "intermediate" }}
+  # Intermediate cipher suite (default) from https://wiki.mozilla.org/Security/Server_Side_TLS
+  ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS;
+{{- else if eq (env "ROUTER_CIPHERS" "intermediate") "old" }}
+  # Old cipher suite (maximum compatibility but insecure) from https://wiki.mozilla.org/Security/Server_Side_TLS
+  ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:DES-CBC3-SHA:HIGH:SEED:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!RSAPSK:!aDH:!aECDH:!EDH-DSS-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!SRP;
+{{- else }}
+  # user provided list of ciphers (Colon separated list as seen above)
+  # the env default is not used here since we can't get here with empty ROUTER_CIPHERS
+  ssl_ciphers {{env "ROUTER_CIPHERS" "ECDHE-ECDSA-CHACHA20-POLY1305"}};
+{{- end }}
+
 
   upstream https-route {
     server 127.0.0.1:{{env "ROUTER_SERVICE_SNI_PORT" "10444"}};
@@ -326,12 +355,13 @@ stream {
   map $ssl_preread_server_name $dest_passthrough {
   {{- range $cfgIdx, $cfg := .State }}
     {{ if eq $cfg.TLSTermination "passthrough" }}
-    {{ $cfg.Host }} 127.0.0.1:{{ env "ROUTER_SERVICE_INTERNAL_PASSTHROUGH_PORT" "10447" }}; 
+    {{ $cfg.Host }} 127.0.0.1:{{ env "ROUTER_SERVICE_INTERNAL_PASSTHROUGH_PORT" "10447" }};
     {{ end }}
   {{ end }}
     default https-route;
   }
 
+  # passthrough routes
   server {
     listen {{ $passthroughPort }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} proxy_protocol{{ end }};
     {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
@@ -348,6 +378,7 @@ stream {
     {{ end }}
   }
 
+  # passthrough upstreams
   {{- range $cfgIdx, $cfg := .State }}
     {{ if eq $cfg.TLSTermination "passthrough" }}
   upstream be_passthrough_{{$cfg.Namespace}}_{{$cfg.Name}} {
@@ -377,7 +408,7 @@ stream {
   map $ssl_preread_server_name $dest_internal_passthrough {
   {{- range $cfgIdx, $cfg := .State }}
     {{ if eq $cfg.TLSTermination "passthrough" }}
-    {{ $cfg.Host }} be_passthrough_{{$cfg.Namespace}}_{{$cfg.Name}}; 
+    {{ $cfg.Host }} be_passthrough_{{$cfg.Namespace}}_{{$cfg.Name}};
     {{ end }}
   {{ end }}
     default 127.0.0.1:{{env "ROUTER_SERVICE_UNREACHABLE_PORT" "10446"}};
@@ -397,5 +428,91 @@ stream {
     status_zone internal_passthrough;
     proxy_pass $dest_internal_passthrough;
   }
+
+  # TCP/UDP upstreams
+{{- range $cfgIdx, $cfg := .State }}
+  {{- with $streamProtocol := firstMatch "tcp|udp" (index $cfg.Annotations "nginx.router.openshift.io/protocol") }}
+    {{- with $streamPort := index $cfg.Annotations "nginx.router.openshift.io/port" }}
+      {{- if isInteger $streamPort }}
+        {{ if not (firstMatch (index $cfg.Annotations "nginx.router.openshift.io/port") (env "ROUTER_SERVICE_HTTPS_PORT" "443") (env "ROUTER_SERVICE_PASSTHROUGH_PORT" "443") (env "ROUTER_SERVICE_HTTP_PORT" "80") (env "ROUTER_SERVICE_SNI_PORT" "10444") (env "ROUTER_SERVICE_503_SERVER_PORT" "10445") (env "ROUTER_SERVICE_UNREACHABLE_PORT" "10446") (env "ROUTER_SERVICE_INTERNAL_PASSTHROUGH_PORT" "10447") "1936") }}
+  upstream be_stream_{{$cfg.Namespace}}_{{$cfg.Name}} {
+          {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") }}
+            {{ if eq $balanceAlgo "ip_hash" }}
+    hash $remote_addr consistent;
+            {{ else if ne $balanceAlgo "round_robin" }}
+    {{ $balanceAlgo }};
+            {{ end }}
+          {{ end }}
+    zone stream_{{$cfg.Namespace}}_{{$cfg.Name}} 64k;
+          {{ if gt $cfg.ActiveEndpoints 0 }}
+            {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
+              {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
+                {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
+    server {{$endpoint.IP}}:{{$endpoint.Port}};
+                {{ end -}}
+              {{ end -}}
+            {{ end -}}
+          {{ end }}
+  }
+
+    # tcp/udp server
+  server {
+          {{- if eq $streamProtocol "tcp" }}
+            {{- if (or (eq $cfg.TLSTermination "edge") (eq $cfg.TLSTermination "reencrypt")) }}
+              {{ $cert := index $cfg.Certificates $cfg.Host -}}
+              {{ if ne $cert.Contents "" }}
+    ssl_certificate     {{$workingDir}}/certs/{{$cfgIdx}}.pem;
+    ssl_certificate_key {{$workingDir}}/certs/{{$cfgIdx}}.pem;
+              {{ else }}
+    ssl_certificate {{ printf "%s/tls.crt" (env "DEFAULT_CERTIFICATE_DIR" "/etc/pki/tls/private") }};
+    ssl_certificate_key {{ printf "%s/tls.key" (env "DEFAULT_CERTIFICATE_DIR" "/etc/pki/tls/private") }};
+              {{ end }}
+    listen {{ $streamPort }} ssl{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} proxy_protocol{{ end }};
+            {{ else }}
+    listen {{ $streamPort }}{{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }} proxy_protocol{{ end }};
+            {{ end }}
+
+            {{ if eq $cfg.TLSTermination "reencrypt" }}
+    proxy_ssl on;
+            {{ with $ssl_name := index $cfg.Annotations "nginx.router.openshift.io/proxy_ssl_name" }}
+    proxy_ssl_name {{ $ssl_name }};
+            {{ else }}
+    proxy_ssl_name {{ $cfg.Host }};
+            {{ end }}
+              {{- if gt (len (index $cfg.Certificates (printf "%s_pod" $cfg.Host)).Contents) 0 }}
+    proxy_ssl_trusted_certificate {{ $workingDir }}/cacerts/{{$cfgIdx}}.pem;
+    proxy_ssl_verify on;
+              {{ else if gt (len $defaultDestinationCA) 0 }}
+    proxy_ssl_trusted_certificate {{ $defaultDestinationCA }};
+    proxy_ssl_verify on;
+              {{ else }}
+    proxy_ssl_verify off;
+              {{ end }}
+            {{ end }}
+            {{ if isTrue (env "ROUTER_USE_PROXY_PROTOCOL") }}
+    set_real_ip_from {{ env "ROUTER_PROXY_PROTOCOL_TRUSTED_SOURCE" "0.0.0.0/0" }};
+            {{ end }}
+          {{ else }}
+    listen {{ $streamPort }} udp;
+
+            {{- with $proxyResponses := index $cfg.Annotations "nginx.router.openshift.io/responses" }}
+              {{- if isInteger $proxyResponses }}
+    proxy_responses {{ $proxyResponses}};
+              {{ end -}}
+            {{ end -}}
+          {{ end -}}
+          {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
+    access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} stream;
+          {{ else }}
+    access_log /var/lib/nginx/log/stream_access.log stream;
+          {{ end }}
+    status_zone {{$streamPort}}_{{$streamProtocol}}_{{$cfg.Name}};
+    proxy_pass be_stream_{{$cfg.Namespace}}_{{$cfg.Name}};
+  }
+        {{ end -}}
+      {{ end -}}
+    {{ end -}}
+  {{ end -}}
+{{ end }}
 }
 {{ end -}}{{/* end config file */}}


### PR DESCRIPTION
Added TCP/UDP load balancing support
- basic tcp
- tcp with tls edge termination
- tcp with tls reencrypt
- tcp with proxy_protocol
- basic udp
- syslog support
- logging

Added new annotations:
- nginx.router.openshift.io/protocol
- nginx.router.openshift.io/port
- nginx.router.openshift.io/responses (udp specific)
- nginx.router.openshift.io/proxy_ssl_name

Added TCP/UDP load balancing documentation and example.