### PR TITLE
Update label selector for Router

### DIFF
--- a/docs/nginx-oss-router-install.md
+++ b/docs/nginx-oss-router-install.md
@@ -35,11 +35,11 @@
 
 1. Deploy the NGINX Router:
     ```
-    $ oc adm router router --images=<image> --type='' --selector='region=infra'
+    $ oc adm router router --images=<image> --type='' --selector='node-role.kubernetes.io/infra=true'
     ```
     **Note**: 
     * The `<image>` must point to the NGINX Router image in your registry.
-    * The selector parameter specifies a label selector for nodes where the Router will be deployed: `region=infra`. Use a selector that makes sense for your environment.
+    * The selector parameter specifies a label selector for nodes where the Router will be deployed: `node-role.kubernetes.io/infra=true`. Use a selector that makes sense for your environment.
 
 1. Run the following command to make sure that the Router pods are running:
     ```

--- a/docs/nginx-plus-router-install.md
+++ b/docs/nginx-plus-router-install.md
@@ -34,12 +34,12 @@
 
 1. Deploy the NGINX Plus Router:
     ```
-    $ oc adm router router --images=docker-registry.default.svc:5000/openshift/nginx-plus-router:0.1 --type='' --selector='region=infra'
+    $ oc adm router router --images=docker-registry.default.svc:5000/openshift/nginx-plus-router:0.1 --type='' --selector='node-role.kubernetes.io/infra=true'
     ```
 
     **Note**: 
     * The NGINX Plus Router image must be stored in the `openshift` directory, with the name `nginx-plus-router:0.1`
-    * The selector parameter specifies a label selector for nodes where the Router will be deployed: `region=infra`. Use a selector that makes sense for your environment.
+    * The selector parameter specifies a label selector for nodes where the Router will be deployed: `node-role.kubernetes.io/infra=true`. Use a selector that makes sense for your environment.
 
 1. Run the following command to make sure that the Router pods are running:
     ```


### PR DESCRIPTION
### Proposed changes

Update the label selector used in the install docs for the Router. In OS 3.10, the label for infra nodes was changed to `node-role.kubernetes.io/infra=true`

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-plus-router/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

