### PR TITLE
Add Performance Tuning to OSS/Plus Router

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,11 @@ The NGINX Router includes the following additional environment variables:
 * `ROUTER_SYSLOG_FORMAT_FOR_INTERNAL_PASSTHROUGH`. Specifies the log format for the internal server that routes passthrough connections.
 * `ROUTER_SERVICE_503_SERVER_PORT`. Specifies the port of the helper server, which serves 503 error pages.
 * `ROUTER_SERVICE_PASSTHROUGH_PORT`. Specifies the port of the passthrough server -- the server, which handles both HTTPS and passthrough connections, before forwarding them to the Router internal helper servers. The default is `443` and equal to `ROUTER_SERVICE_HTTPS_PORT`. However, `ROUTER_SERVICE_PASSTHROUGH_PORT` and `ROUTER_SERVICE_HTTPS_PORT` can be different. In that case the server on the passthrough port will only handle passthrough connections and the server on the HTTPS port will only handle HTTPS connections.
+* `KEEPALIVE_REQUESTS`. Specifies the maximum number of requests NGINX can serve through a single keep-alive connection. The default value is `100`.
+* `WORKER_PROCESSES`. Specifies the number of worker processes, and is used to help tune NGINX performance. To see the list of factors that influences the optimal value, see [our documentation](http://nginx.org/en/docs/ngx_core_module.html#worker_processes). It is considered a good start to set this value to the number of CPU cores of the node in which the router is running. Leaving this value to default will allow NGINX to try and autodetect it.
+* `WORKER_CPU_AFFINITY`. Tied closely with `WORKER_PROCESSES`, this value binds worker processes to the sets of CPUs. Each CPU set is represented by a bitmask of allowed CPUs. See the [documentation](http://nginx.org/en/docs/ngx_core_module.html#worker_cpu_affinity) for examples of how to use it.
+* `WORKER_RLIMIT_NOFILE`. Specifies the maximum number of open files for worker processes. The default value is `8192`, but it can be useful to increase this number when NGINX is handling a large number of connections.
+
 
 ## Annotations
 

--- a/src/nginx-plus/conf/nginx-config.template
+++ b/src/nginx-plus/conf/nginx-config.template
@@ -8,14 +8,17 @@
 {{ $httpsPort := env "ROUTER_SERVICE_HTTPS_PORT" "443" }}
 {{ $passthroughPort := env "ROUTER_SERVICE_PASSTHROUGH_PORT" "443" }}
 {{ $logLevel := firstMatch "info|notice|warn|error|crit|alert|emerg" (env "ROUTER_LOG_LEVEL") "warn" }}
-worker_processes  auto;
+worker_processes {{ env "WORKER_PROCESSES" "auto" }};
+{{ with $cpuAffinity := env "WORKER_CPU_AFFINITY" }}
+worker_cpu_affinity {{ $cpuAffinity }};
+{{ end }}
 {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
 error_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}} {{ $logLevel }};
 {{ else }}
 error_log  /var/lib/nginx/log/error.log {{ $logLevel }};
 {{ end }}
 pid        /var/lib/nginx/run/nginx.pid;
-worker_rlimit_nofile 8192;
+worker_rlimit_nofile {{ env "WORKER_RLIMIT_NOFILE" "8192" }};
 worker_shutdown_timeout {{ env "ROUTER_DEFAULT_TUNNEL_TIMEOUT" "1h" }};
 
 events {
@@ -47,6 +50,7 @@ http {
   uwsgi_temp_path /var/lib/nginx/cache/uwsgi_temp;
   scgi_temp_path /var/lib/nginx/cache/scgi_temp;
 
+  keepalive_requests {{ env "KEEPALIVE_REQUESTS" "100" }};
   keepalive_timeout {{ env "ROUTER_SLOWLORIS_HTTP_KEEPALIVE" "300s" }};
 
   client_body_timeout {{ env "ROUTER_DEFAULT_CLIENT_TIMEOUT" "30s" }};

--- a/src/nginx/conf/nginx-config.template
+++ b/src/nginx/conf/nginx-config.template
@@ -8,14 +8,17 @@
 {{ $httpsPort := env "ROUTER_SERVICE_HTTPS_PORT" "443" }}
 {{ $passthroughPort := env "ROUTER_SERVICE_PASSTHROUGH_PORT" "443" }}
 {{ $logLevel := firstMatch "info|notice|warn|error|crit|alert|emerg" (env "ROUTER_LOG_LEVEL") "warn" }}
-worker_processes  auto;
+worker_processes {{ env "WORKER_PROCESSES" "auto" }};
+{{ with $cpuAffinity := env "WORKER_CPU_AFFINITY" }}
+worker_cpu_affinity {{ $cpuAffinity }};
+{{ end }}
 {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
 error_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}} {{ $logLevel }}; 
 {{ else }}
 error_log  /var/lib/nginx/log/error.log {{ $logLevel }};
 {{ end }} 
 pid        /var/lib/nginx/run/nginx.pid;
-worker_rlimit_nofile 8192;
+worker_rlimit_nofile {{ env "WORKER_RLIMIT_NOFILE" "8192" }};
 worker_shutdown_timeout {{ env "ROUTER_DEFAULT_TUNNEL_TIMEOUT" "1h" }};
 
 events {
@@ -47,6 +50,7 @@ http {
   uwsgi_temp_path /var/lib/nginx/cache/uwsgi_temp;
   scgi_temp_path /var/lib/nginx/cache/scgi_temp;
 
+  keepalive_requests {{ env "KEEPALIVE_REQUESTS" "100" }};
   keepalive_timeout {{ env "ROUTER_SLOWLORIS_HTTP_KEEPALIVE" "300s" }};
 
   client_body_timeout {{ env "ROUTER_DEFAULT_CLIENT_TIMEOUT" "30s" }};


### PR DESCRIPTION
Add performance tuning to NGINX and NGINX Plus Routers. Includes:

- worker_processes
- worker_cpu_affinity
- keepalive_requests
- worker_rlimit_nofile

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-openshift-router/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

