### PR TITLE
Add Advanced Load Balancing Methods to Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NGINX Router is built on top of OpenShift Template Router. Below are the key fea
 * **Latest NGINX features.** We are also excited to bring our new features, such as native support for gRPC load balancing, into the OpenShift Router. As new features are made available in NGINX and NGINX Plus, they can be incorporated into the Router’s capabilities. 
 * **Support for TCP/UDP load balancing.** NGINX Router brings support for load balancing TCP/UDP applications, including supporting edge TLS termination and re-encryption for TCP, via a TCP/UDP load balancing [extension](docs/configuration.md/#tcpudp-load-balancing-extension).
 * **Support for Prometheus**. NGINX Router can optionally expose metrics ready to be collected by [Prometheus](https://prometheus.io/).
-* **Advanced features of NGINX Plus.** When NGINX Router is used with NGINX Plus, you get the additional benefits of NGINX Plus, such as its monitoring API, dashboard and extended number of metrics for Prometheus.
+* **Advanced features of NGINX Plus.** When NGINX Router is used with NGINX Plus, you get the additional benefits of NGINX Plus, such as its monitoring API, dashboard, extended number of metrics for Prometheus and more [fine-tuned](docs/configuration.md#fine-tuning-load-balancing-methods-with-nginx-plus) control over load balancing methods.
 
 ## How To Get Started
 

--- a/src/nginx-plus/conf/nginx-config.template
+++ b/src/nginx-plus/conf/nginx-config.template
@@ -154,14 +154,29 @@ http {
     }
   }
 
-{{- range $cfgHost, $configs := $httpAliases }}
+# HTTP Upstreams
+{{range $cfgHost, $configs := $httpAliases }}
   {{- range $cfg := $configs }}
     {{- if not (and (firstMatch "tcp|udp" (index $cfg.Annotations "nginx.router.openshift.io/protocol")) (isInteger (index $cfg.Annotations "nginx.router.openshift.io/port"))) }}
   upstream be_{{$cfg.Namespace}}_{{$cfg.Name}} {
-      {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
-        {{ if ne $balanceAlgo "round_robin" }}
+      {{ with $balanceAlgo := firstMatch "round_robin|least_time|random|random_two|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") "random_two" }}
+        {{ if eq $balanceAlgo "least_time" }}
+          {{ with $balanceParameters := firstMatch "header|last_byte|header inflight|last_byte inflight" (index $cfg.Annotations "nginx.router.openshift.io/balance-parameters") (env "ROUTER_HTTP_BALANCE_PARAMETERS") "header" }}
+    least_time {{ $balanceParameters }};
+          {{ else }}
+    least_time header;
+          {{ end}}
+        {{ else if eq $balanceAlgo "random_two" }}
+          {{ with $balanceParameters := firstMatch "least_conn|least_time=header|least_time=last_byte" (index $cfg.Annotations "nginx.router.openshift.io/balance-parameters") (env "ROUTER_HTTP_BALANCE_PARAMETERS") "least_conn" }}
+    random two {{ $balanceParameters }};
+          {{ else }}
+    random two least_conn;
+          {{ end }}
+        {{ else if ne $balanceAlgo "round_robin" }}
     {{ $balanceAlgo }};
         {{ end }}
+      {{ else }}
+    random two least_conn;
       {{ end }}
     zone {{$cfg.Namespace}}_{{$cfg.Name}} 64k;
       {{ if gt $cfg.ActiveEndpoints 0 }}
@@ -386,12 +401,26 @@ stream {
   {{- range $cfgIdx, $cfg := .State }}
     {{ if eq $cfg.TLSTermination "passthrough" }}
   upstream be_passthrough_{{$cfg.Namespace}}_{{$cfg.Name}} {
-      {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") }}
+      {{ with $balanceAlgo := firstMatch "round_robin|least_time|random|random_two|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") "random_two" }}
         {{ if eq $balanceAlgo "ip_hash" }}
     hash $remote_addr consistent;
+        {{ else if eq $balanceAlgo "least_time" }}
+          {{ with $balanceParameters := firstMatch "connect|first_byte|last_byte|connect inflight|first_byte inflight|last_byte inflight" (index $cfg.Annotations "nginx.router.openshift.io/balance-parameters") (env "ROUTER_TCP_BALANCE_PARAMETERS") "connect" }}
+    least_time {{ $balanceParameters }};
+          {{ else }}
+    least_time connect;
+          {{ end}}
+        {{ else if eq $balanceAlgo "random_two" }}
+          {{ with $balanceParameters := firstMatch "least_conn|least_time=connect|least_time=first_byte|least_time=last_byte" (index $cfg.Annotations "nginx.router.openshift.io/balance-parameters") (env "ROUTER_TCP_BALANCE_PARAMETERS") "least_conn" }}
+    random two {{ $balanceParameters }};
+          {{ else }}
+    random two least_conn;
+          {{ end }}
         {{ else if ne $balanceAlgo "round_robin" }}
     {{ $balanceAlgo }};
         {{ end }}
+      {{ else }}
+    random two least_conn;
       {{ end }}
     zone {{$cfg.Namespace}}_{{$cfg.Name}} 64k;
       {{ if gt $cfg.ActiveEndpoints 0 }}
@@ -440,12 +469,26 @@ stream {
       {{- if isInteger $streamPort }}
         {{ if not (firstMatch (index $cfg.Annotations "nginx.router.openshift.io/port") (env "ROUTER_SERVICE_HTTPS_PORT" "443") (env "ROUTER_SERVICE_PASSTHROUGH_PORT" "443") (env "ROUTER_SERVICE_HTTP_PORT" "80") (env "ROUTER_SERVICE_SNI_PORT" "10444") (env "ROUTER_SERVICE_503_SERVER_PORT" "10445") (env "ROUTER_SERVICE_UNREACHABLE_PORT" "10446") (env "ROUTER_SERVICE_INTERNAL_PASSTHROUGH_PORT" "10447") "1936") }}
   upstream be_stream_{{$cfg.Namespace}}_{{$cfg.Name}} {
-          {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") }}
+          {{ with $balanceAlgo := firstMatch "round_robin|least_time|random|random_two|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") "random_two" }}
             {{ if eq $balanceAlgo "ip_hash" }}
     hash $remote_addr consistent;
+            {{ else if eq $balanceAlgo "least_time" }}
+              {{ with $balanceParameters := firstMatch "connect|first_byte|last_byte|connect inflight|first_byte inflight|last_byte inflight" (index $cfg.Annotations "nginx.router.openshift.io/balance-parameters") (env "ROUTER_TCP_BALANCE_PARAMETERS") "connect" }}
+    least_time {{ $balanceParameters }};
+              {{ else }}
+    least_time connect;
+              {{ end}}
+            {{ else if eq $balanceAlgo "random_two" }}
+              {{ with $balanceParameters := firstMatch "least_conn|least_time=connect|least_time=first_byte|least_time=last_byte" (index $cfg.Annotations "nginx.router.openshift.io/balance-parameters") (env "ROUTER_TCP_BALANCE_PARAMETERS") "least_conn" }}
+    random two {{ $balanceParameters }};
+              {{ else }}
+    random two least_conn;
+              {{ end }}
             {{ else if ne $balanceAlgo "round_robin" }}
     {{ $balanceAlgo }};
             {{ end }}
+          {{ else }}
+    random two least_conn;
           {{ end }}
     zone stream_{{$cfg.Namespace}}_{{$cfg.Name}} 64k;
           {{ if gt $cfg.ActiveEndpoints 0 }}

--- a/src/nginx/conf/nginx-config.template
+++ b/src/nginx/conf/nginx-config.template
@@ -146,14 +146,19 @@ http {
     }
   }
 
-{{- range $cfgHost, $configs := $httpAliases }}
+# HTTP Upstreams
+{{range $cfgHost, $configs := $httpAliases }}
   {{- range $cfg := $configs }}
     {{- if not (and (firstMatch "tcp|udp" (index $cfg.Annotations "nginx.router.openshift.io/protocol")) (isInteger (index $cfg.Annotations "nginx.router.openshift.io/port"))) }}
   upstream be_{{$cfg.Namespace}}_{{$cfg.Name}} {
-      {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") }}
-        {{ if ne $balanceAlgo "round_robin" }}
+      {{ with $balanceAlgo := firstMatch "round_robin|random|random_two|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_LOAD_BALANCE_ALGORITHM") "random_two" }}
+        {{ if eq $balanceAlgo "random_two" }}
+    random two least_conn;
+        {{ else if ne $balanceAlgo "round_robin" }}
     {{ $balanceAlgo }};
         {{ end }}
+      {{ else }}
+    random two least_conn;
       {{ end }}
       {{ if gt $cfg.ActiveEndpoints 0 }}
         {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
@@ -373,12 +378,16 @@ stream {
   {{- range $cfgIdx, $cfg := .State }}
     {{ if eq $cfg.TLSTermination "passthrough" }}
   upstream be_passthrough_{{$cfg.Namespace}}_{{$cfg.Name}} {
-      {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") }}
+      {{ with $balanceAlgo := firstMatch "round_robin|random|random_two|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") "random_two" }}
         {{ if eq $balanceAlgo "ip_hash" }}
     hash $remote_addr consistent;
+        {{ else if eq $balanceAlgo "random_two" }}
+    random two least_conn;
         {{ else if ne $balanceAlgo "round_robin" }}
     {{ $balanceAlgo }};
         {{ end }}
+      {{ else }}
+    random two least_conn;
       {{ end }}
       {{ if gt $cfg.ActiveEndpoints 0 }}
         {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
@@ -426,12 +435,16 @@ stream {
       {{- if isInteger $streamPort }}
         {{ if not (firstMatch (index $cfg.Annotations "nginx.router.openshift.io/port") (env "ROUTER_SERVICE_HTTPS_PORT" "443") (env "ROUTER_SERVICE_PASSTHROUGH_PORT" "443") (env "ROUTER_SERVICE_HTTP_PORT" "80") (env "ROUTER_SERVICE_SNI_PORT" "10444") (env "ROUTER_SERVICE_503_SERVER_PORT" "10445") (env "ROUTER_SERVICE_UNREACHABLE_PORT" "10446") (env "ROUTER_SERVICE_INTERNAL_PASSTHROUGH_PORT" "10447") "1936") }}
   upstream be_stream_{{$cfg.Namespace}}_{{$cfg.Name}} {
-          {{ with $balanceAlgo := firstMatch "round_robin|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") }}
+          {{ with $balanceAlgo := firstMatch "round_robin|random|random_two|least_conn|ip_hash" (index $cfg.Annotations "nginx.router.openshift.io/balance") (env "ROUTER_TCP_BALANCE_SCHEME") "random_two" }}
             {{ if eq $balanceAlgo "ip_hash" }}
     hash $remote_addr consistent;
+            {{ else if eq $balanceAlgo "random_two" }}
+    random two least_conn;
             {{ else if ne $balanceAlgo "round_robin" }}
     {{ $balanceAlgo }};
             {{ end }}
+          {{ else }}
+    random two least_conn;
           {{ end }}
           {{ if gt $cfg.ActiveEndpoints 0 }}
             {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}


### PR DESCRIPTION
Add advanced load balancing methods to NGINX and NGINX Plus Routers and update respective documentation. Methods include:

NGINX Router:
HTTP/TCP:

* random
* random_two_least_conn

NGINX Router with NGINX Plus
HTTP:

* random
* random two least_conn
* random two least_time=header
* random two least_time=last_byte
* least_time header
* least_time last_byte
* least_time header inflight
* least_time last_byte inflight
TCP:

* random
* random two least_conn
* random two least_time=connect
* random two least_time=first_byte
* random two least_time=last_byte
* least_time connect
* least_time first_byte
* least_time last_byte
* least_time connect inflight
* least_time first_byte inflight
* least_time last_byte inflight

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-openshift-router/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

