### PR TITLE
 Support weights in passthrough and TCP/UDP routes. Fix a bug with zero weights for HTTP Routes

### DIFF
--- a/src/nginx-plus/conf/nginx-config.template
+++ b/src/nginx-plus/conf/nginx-config.template
@@ -427,7 +427,7 @@ stream {
         {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
           {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
             {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-    server {{$endpoint.IP}}:{{$endpoint.Port}};
+    server {{$endpoint.IP}}:{{$endpoint.Port}} {{ if eq $weight 0 }}down{{ else }}weight={{ $weight }}{{ end }};
             {{ end -}}
           {{ end -}}
         {{ end -}}
@@ -495,7 +495,7 @@ stream {
             {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
               {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
                 {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-    server {{$endpoint.IP}}:{{$endpoint.Port}};
+    server {{$endpoint.IP}}:{{$endpoint.Port}} {{ if eq $weight 0 }}down{{ else }}weight={{ $weight }}{{ end }};
                 {{ end -}}
               {{ end -}}
             {{ end -}}

--- a/src/nginx-plus/conf/nginx-config.template
+++ b/src/nginx-plus/conf/nginx-config.template
@@ -184,7 +184,7 @@ http {
         # endpoints of {{$serviceUnitName}}
           {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
             {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-    server {{$endpoint.IP}}:{{$endpoint.Port}} weight={{$weight}};
+    server {{$endpoint.IP}}:{{$endpoint.Port}} {{ if eq $weight 0 }}down{{ else }}weight={{ $weight }}{{ end }};
             {{ end -}}
           {{ end }}
         {{ end -}}

--- a/src/nginx/conf/nginx-config.template
+++ b/src/nginx/conf/nginx-config.template
@@ -393,7 +393,7 @@ stream {
         {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
           {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
             {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-    server {{$endpoint.IP}}:{{$endpoint.Port}};
+    server {{$endpoint.IP}}:{{$endpoint.Port}} {{ if eq $weight 0 }}down{{ else }}weight={{ $weight }}{{ end }};
             {{ end -}}
           {{ end -}}
         {{ end -}}
@@ -450,7 +450,7 @@ stream {
             {{- range $serviceUnitName, $weight := $cfg.ServiceUnitNames }}
               {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
                 {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-    server {{$endpoint.IP}}:{{$endpoint.Port}};
+    server {{$endpoint.IP}}:{{$endpoint.Port}} {{ if eq $weight 0 }}down{{ else }}weight={{ $weight }}{{ end }};
                 {{ end -}}
               {{ end -}}
             {{ end -}}

--- a/src/nginx/conf/nginx-config.template
+++ b/src/nginx/conf/nginx-config.template
@@ -165,7 +165,7 @@ http {
         # endpoints of {{$serviceUnitName}} 
           {{- with $serviceUnit := index $.ServiceUnits $serviceUnitName }}
             {{- range $idx, $endpoint := endpointsForAlias $cfg $serviceUnit }}
-    server {{$endpoint.IP}}:{{$endpoint.Port}} weight={{$weight}};
+    server {{$endpoint.IP}}:{{$endpoint.Port}} {{ if eq $weight 0 }}down{{ else }}weight={{ $weight }}{{ end }};
             {{ end -}}
           {{ end }}
         {{ end -}}


### PR DESCRIPTION
### Proposed changes
*  Support weights in passthrough and TCP/UDP routes
*  Fix a bug with zero weights for HTTP Routes (fixes https://github.com/nginxinc/nginx-openshift-router/issues/13)

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-openshift-router/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [x] I have rebased my branch onto master

