### PR TITLE
Print access logs to console rather than a file

### DIFF
--- a/src/nginx-plus/conf/nginx-config.template
+++ b/src/nginx-plus/conf/nginx-config.template
@@ -38,7 +38,7 @@ http {
 {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
   access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} main;
 {{ else }}
-  access_log   /var/lib/nginx/log/access.log  main;
+  access_log   /proc/1/fd/1 main;
 {{ end }}
   sendfile     on;
   tcp_nopush   on;
@@ -411,7 +411,7 @@ stream {
     {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
     access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} passthrough;
     {{ else }}
-    access_log /var/lib/nginx/log/passthrough_access.log passthrough;
+    access_log /proc/1/fd/1 passthrough;
     {{ end }}
     status_zone passthrough;
     proxy_pass $dest_passthrough;
@@ -478,7 +478,7 @@ stream {
     {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
     access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} internal_passthrough;
     {{ else }}
-    access_log /var/lib/nginx/log/internal_passthrough_access.log internal_passthrough;
+    access_log /proc/1/fd/1 internal_passthrough;
     {{ end }}
 
     ssl_preread on;
@@ -576,7 +576,7 @@ stream {
           {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
     access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} stream;
           {{ else }}
-    access_log /var/lib/nginx/log/stream_access.log stream;
+    access_log /proc/1/fd/1 stream;
           {{ end }}
     status_zone {{$streamPort}}_{{$streamProtocol}}_{{$cfg.Name}};
     proxy_pass be_stream_{{$cfg.Namespace}}_{{$cfg.Name}};

--- a/src/nginx/conf/nginx-config.template
+++ b/src/nginx/conf/nginx-config.template
@@ -38,7 +38,7 @@ http {
 {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
   access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} main;
 {{ else }}
-  access_log   /var/lib/nginx/log/access.log  main;
+  access_log   /proc/1/fd/1  main;
 {{ end }}
   sendfile     on;
   tcp_nopush   on;
@@ -389,7 +389,7 @@ stream {
     {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
     access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} passthrough;
     {{ else }}
-    access_log /var/lib/nginx/log/passthrough_access.log passthrough;
+    access_log /proc/1/fd/1 passthrough;
     {{ end }}
     proxy_pass $dest_passthrough;
     ssl_preread on;
@@ -444,7 +444,7 @@ stream {
     {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
     access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} internal_passthrough;
     {{ else }}
-    access_log /var/lib/nginx/log/internal_passthrough_access.log internal_passthrough;
+    access_log /proc/1/fd/1 internal_passthrough;
     {{ end }}
 
     ssl_preread on;
@@ -531,7 +531,7 @@ stream {
           {{ with $syslogAddress := env "ROUTER_SYSLOG_ADDRESS" }}
     access_log syslog:server={{ $syslogAddress }},facility={{env "ROUTER_LOG_FACILITY" "local1"}},severity={{ $logLevel }} stream;
           {{ else }}
-    access_log /var/lib/nginx/log/stream_access.log stream;
+    access_log /proc/1/fd/1 stream;
           {{ end }}
     proxy_pass be_stream_{{$cfg.Namespace}}_{{$cfg.Name}};
 


### PR DESCRIPTION
### Proposed changes
Since this Nginx configuration is meant to be used as a Router running as a container in OpenShift, access logs should be printed to the console log in order to be accessible from the console and collected with Elastic. It will also prevent the local container storage from running full.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-openshift-router/blob/master/CONTRIBUTING.md) guide
- [x] I have proven my fix is effective or that my feature works
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch on my own fork

